### PR TITLE
Added recipe to install the wkhtmltopdf CLI

### DIFF
--- a/wkhtmltopdf/metadata.rb
+++ b/wkhtmltopdf/metadata.rb
@@ -1,0 +1,4 @@
+name        "wkhtmltopdf"
+description "Installs and configures the wkhtmltopdf CLI"
+
+recipe 'wkhtmltopdf::install', "Installs wkhtmltopdf CLI"

--- a/wkhtmltopdf/recipes/install.rb
+++ b/wkhtmltopdf/recipes/install.rb
@@ -1,0 +1,10 @@
+remote_file "#{Chef::Config[:file_cache_path]}/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb" do
+  source "http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb"
+  owner "root"
+  group "root"
+end
+
+execute "install_wkhtmltopdf" do
+  command "gdebi -n #{Chef::Config[:file_cache_path]}/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb"
+  user "root"
+end


### PR DESCRIPTION
Requires the `gdebi-core` OS Package to be installed in order to work
